### PR TITLE
Use the custom project name for the local URL

### DIFF
--- a/ocpintro/ocpintro/4.11/009_networking_applications.html
+++ b/ocpintro/ocpintro/4.11/009_networking_applications.html
@@ -509,7 +509,7 @@ from where you are in the instructions.</p>
 </div>
 <div class="listingblock console-input">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">curl http://application3.redhat-training.svc.cluster.local:8080</code></pre>
+<pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">curl http://application3.%PROJECT%.svc.cluster.local:8080</code></pre>
 </div>
 </div>
 <div class="admonitionblock tip">


### PR DESCRIPTION
The default value doesn't resolve as the project isn't called `redhat-training`. Looking in `/etc/resolv.conf` in the pod, I see that my DNS config searches for `project-name.svc.cluster.local` (amongst others), so I assume we can use the `%PROJECT%` value in this URL.